### PR TITLE
Working solution for ack backs.

### DIFF
--- a/MBC_UserDigest.class.inc
+++ b/MBC_UserDigest.class.inc
@@ -83,7 +83,7 @@ class MBC_UserDigest
 
     // Stathat
     $this->statHat = new StatHat($this->settings['stathat_ez_key'], 'mbc-digest-email:');
-    $this->statHat->setIsProduction(FALSE);
+    $this->statHat->setIsProduction(TRUE);
   }
 
   /**
@@ -144,8 +144,12 @@ class MBC_UserDigest
     while ($messageCount > 0 && $processedCount < self::BATCH_SIZE) {
 
       $messageDetails = $this->channel->basic_get($this->config['queue'][0]['name']);
-      // @todo: AckBacks not working - fix.
+
+      // @todo: The channel details are missing when messageBroker->sendAck is
+      // called. Need to restore sendAck functionality in messagebroker-phplib
       // $this->messageBroker->sendAck($messageDetails);
+      $this->channel->basic_ack($messageDetails->delivery_info['delivery_tag']);
+
       $messagePayload = json_decode($messageDetails->body);
       $targetUsers[$processedCount] = array(
         'email' => $messagePayload->email,
@@ -584,6 +588,7 @@ class MBC_UserDigest
 
     }
 
+    echo '------- mbc-digest-email composeMergeVars: ' . count($mergeVars) . ' messages composed - ' . date('D M j G:i:s T Y') . ' -------', "\n";
     return array($mergeVars, $targetUsers);
   }
 
@@ -620,11 +625,12 @@ class MBC_UserDigest
     );
 
     $composedDigestSubmission = array(
-    'subject' => '*|FNAME|*\'s weekly DoSomething.org campaign digest',
-    'from_email' => 'help@dosomething.org',
-    'from_name' => 'DoSomething.org',
+//    'subject' => '*|FNAME|*\'s weekly DoSomething.org campaign digest',
+      'subject' => 'Introducing your new campaign digest!',
+      'from_email' => 'help@dosomething.org',
+      'from_name' => 'DoSomething.org',
       'to' => $to,
-    //  'bcc_address' => 'dlee@dosomething.org',
+//      'bcc_address' => 'mlidey@dosomething.org',
       'global_merge_vars' => $globalMergeVars,
       'merge_vars' => $mergeVars,
       'tags' => $tags,

--- a/mbc-digest-email.php
+++ b/mbc-digest-email.php
@@ -45,7 +45,6 @@ $config = array(
   ),
 );
 $settings = array(
-  'mandrill' => '',
   'stathat_ez_key' => getenv("STATHAT_EZKEY"),
 );
 


### PR DESCRIPTION
Fixes #6 

@jonuy The channel details were missing in the `$this->messageBroker->sendAck($messageDetails);` call. `$this->channel->basic_ack($messageDetails->delivery_info['delivery_tag']);` is a working solution but a hack considering it's not using the messagebroker-phplib method.

We'll need to revisit this when we get around to refactoring the library.

Related followup issue:
https://github.com/DoSomething/messagebroker-phplib/issues/27
