### PR TITLE
Comment cleanup /spacing around campaign tip / news

### DIFF
--- a/src/MBC_DigestEmail_Campaign.php
+++ b/src/MBC_DigestEmail_Campaign.php
@@ -17,111 +17,96 @@ class MBC_DigestEmail_Campaign {
 
   /**
    * Singleton instance of application configuration settings.
-   *
-   * @var object
+   * @var object $mbConfig
    */
    private $mbConfig;
 
   /**
    * Singleton instance of class used to report usage statistics.
-   *
-   * @var object
+   * @var object $statHat
    */
    private $statHat;
 
   /**
    * A collection of tools used by all of the Message Broker applications.
-   *
-   * @var object
+   * @var object $mbToolbox
    */
    private $mbToolbox;
 
   /**
-   *
-   *
-   * @var
+   * Campaign title.
+   * @var string $title
    */
    public $title;
 
   /**
    * Needs public scope to allow making reference to campaign nid when assigning campaigns
    * to user objects.
-   *
-   * @var integer
+   * @var integer $drupal_nid
    */
    public $drupal_nid;
 
   /**
    * A flag to determine if the campaign has "staff pick" status. Used for sorting of
    * campaigns in user digest messages.
-   *
-   * @var boolean
+   * @var boolean $is_staff_pick
    */
    public $is_staff_pick;
 
   /**
-   *
-   *
-   * @var string
+   * The url to the campaign web page on the DoSomething.org web site.
+   * @var string $url
    */
    public $url;
 
   /**
-   *
-   *
-   * @var string
+   * Markup for the campaign cover image.
+   * @var string $image_campaign_cover
    */
    public $image_campaign_cover;
 
   /**
    * Campaign text displayed in summary listings to encourage users to take up the
    * "call to action".
-   *
-   * @var string
+   * @var string $call_to_action
    */
    public $call_to_action;
 
   /**
    * The problem that will be addressed by doing the campaign. Used in descriptive text in
    * digest message campaign listings.
-   *
-   * @var string
+   * @var string $fact_problem
    */
    public $fact_problem;
 
   /**
-   *
-   *
-   * @var string
+   * The solution to the problem the campaign is trying to address.
+   * @var string $fact_solution
    */
    public  $fact_solution;
 
   /**
    * Special message from campaign manager about the campaign. Presence of this messages overrides
    * all other campaign descriptive text.
-   *
-   * @var string
+   * @var string $latest_news
    */
    public $latest_news;
 
   /**
-   *
-   *
-   * @var string
+   * The title of the Tip on how to complete the campaign.
+   * @var string $during_tip_header
    */
    public $during_tip_header;
 
   /**
-   *
-   *
-   * @var string
+   * The descriptive ip text.
+   * @var string $during_tip
    */
    public $during_tip;
 
   /**
-   *
-   *
-   * @var
+   * The HTML markup for the campaign to be used in the digest message content.
+   * @var string $markup
    */
    public $markup;
 
@@ -149,7 +134,9 @@ class MBC_DigestEmail_Campaign {
   /**
    * Populate object properties based on campaign lookup on Drupal site.
    *
-   *
+   * @param integer $nid
+   *   The node ID (nid), a unique identifier for the content defined by the Drupal website.
+   *   A campaign has a unique nid.
    */
   private function add($nid) {
 
@@ -176,7 +163,7 @@ class MBC_DigestEmail_Campaign {
     }
     // call_to_action - nice to have but not a show stopper
     if (isset($campaignSettings->call_to_action)) {
-      $this->call_to_action = $campaignSettings->call_to_action;
+      $this->call_to_action = trim($campaignSettings->call_to_action);
     }
     else {
       $this->call_to_action = '';
@@ -185,7 +172,7 @@ class MBC_DigestEmail_Campaign {
     }
     // DO IT: During Tip Header - step_pre[0]->header - nice to have but not a show stopper
     if (isset($campaignSettings->step_pre[0]->header)) {
-      $this->during_tip_header = $campaignSettings->step_pre[0]->header;
+      $this->during_tip_header = trim($campaignSettings->step_pre[0]->header);
     }
     else {
       $this->during_tip_header = '';
@@ -194,7 +181,7 @@ class MBC_DigestEmail_Campaign {
     }
     // DO IT: During Tip Copy - step_pre[0]->copy - nice to have but not a show stopper
     if (isset($campaignSettings->step_pre[0]->copy)) {
-      $this->during_tip_copy = ': ' . strip_tags($campaignSettings->step_pre[0]->copy);
+      $this->during_tip_copy = ': ' . trim(strip_tags($campaignSettings->step_pre[0]->copy));
     }
     else {
       $this->during_tip_copy = '';
@@ -209,15 +196,15 @@ class MBC_DigestEmail_Campaign {
     }
     // latest_news_copy - replaces Tip copy if set.
     if (isset($campaignSettings->latest_news_copy)) {
-      $this->latest_news = strip_tags($campaignSettings->latest_news_copy);
+      $this->latest_news = trim(strip_tags($campaignSettings->latest_news_copy));
     }
   }
 
   /**
-   * Gather campaign properties based on campaign lookup on Drupal site.
+   * Gather campaign properties based on the campaign lookup on the Drupal site.
    *
    * @param integer $nid
-   *   The Drupal nid (node ID) of the terget campaign.
+   *   The Drupal nid (node ID) of the target campaign.
    *
    * @return object
    *   The returned results from the call to the campaign endpoint on the Drupal site.
@@ -241,10 +228,10 @@ class MBC_DigestEmail_Campaign {
       return $result[0];
     }
     elseif ($result[1] == 200 && is_array($result[0])) {
-      throw new Exception('Call to ' . $campaignAPIUrl . ' returned rejected response.' . $nid);
+      throw new Exception('Call to ' . $campaignAPIUrl . ' returned  200 with rejected response. nid: ' . $nid);
     }
     elseif ($result[1] == 403) {
-      throw new Exception('Call to ' . $campaignAPIUrl . ' returned rejected response: ' . $result[0][0] . '.' . $nid);
+      throw new Exception('Call to ' . $campaignAPIUrl . ' returned 403 and rejected response: ' . $result[0][0] . ' . nid: ' . $nid);
     }
     else {
       throw new Exception('Unable to call ' . $campaignAPIUrl . ' to get Campaign object: ' . $nid);


### PR DESCRIPTION
Fixes #60 

Added `trim()` to both title and body variables to ensure extra space is removed.