### PR TITLE
Issue70 campaign concurrency

### DIFF
--- a/mbc-digest-email.config.inc
+++ b/mbc-digest-email.config.inc
@@ -40,6 +40,10 @@ $mbConfig->setProperty('mb_user_api_config', [
   'host' => getenv("MB_USER_API_HOST"),
   'port' => getenv('MB_USER_API_PORT')
 ]);
+$mbConfig->setProperty('mb_digest_api_config', [
+  'host' => getenv("MB_DIGEST_API_HOST"),
+  'port' => getenv('MB_DIGEST_API_PORT')
+]);
 
 $subscriptionsSetting = $mbConfig->gatherSettings('subscriptions');
 $mbConfig->setProperty('subscriptions_config', [

--- a/src/MBC_DigestEmail_API.php
+++ b/src/MBC_DigestEmail_API.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * MBC_DigestEmail_API - Access to mb-digest-api.
+ */
+namespace DoSomething\MBC_DigestEmail;
+
+use DoSomething\MB_Toolbox\MB_Configuration;
+use DoSomething\MB_Toolbox\MB_Toolbox_cURL;
+use DoSomething\StatHat\Client as StatHat;
+
+/**
+ * MBC_DigestEmail_API class - Properties and methods used to access mb-digest-api.
+ */
+class MBC_DigestEmail_API
+{
+
+  /**
+   * Singleton instance of application configuration settings.
+   * @var object $mbConfig
+   */
+  private $mbConfig;
+
+  /**
+   * Configuration settings for mb-digest-api.
+   * @var array $mbDigestAPIConfig
+   */
+  private $mbDigestAPIConfig;
+
+  /**
+   * Collection of methods to perform cURL activities.
+   * @var object $mbToolboxcURL
+   */
+  private $mbToolboxcURL;
+
+  /**
+   * The URL to the mb-digest-api.
+   * @var string $curlUrl
+   */
+  private $curlUrl;
+
+  /**
+   *
+   */
+  public function __init() {
+
+    $this->mbConfig = MB_Configuration::getInstance();
+    $this->mbDigestAPIConfig = $this->mbConfig->getProperty('mb_digest_api_config');
+    $this->mbToolboxcURL = $this->mbConfig->getProperty('mbToolboxcURL');
+    
+    $this->curlUrl = $this->mbDigestAPIConfig['host'];
+    $port = isset($this->mbDigestAPIConfig['port']) ? $this->mbDigestAPIConfig['port'] : NULL;
+    if ($port != 0 && is_numeric($port)) {
+      $this->curlUrl .= ':' . (int) $port;
+    }
+  }
+  
+  /**
+   * campaignGet: Gather (GET) cached campaign object from mb-digest-api.
+   *
+   * @param integer $nid
+   *   The Node ID (nid) of the campaign as defined by the Drupal application.
+   * @param string $language
+   *   The language of the cache campaign entry. A campaign by NID can have
+   *   more than one version by language.
+   */
+  private function campaignGet($nid, $language) {
+    
+    $key = 'mb-digest-campaign-' . $nid . '-' . $language;
+    $mbDigestAPIUrl = $this->curlUrl . '/api/v1/campaign?key=' . $key;
+    $result = $this->mbToolboxcURL->curlGET($mbDigestAPIUrl);
+
+    // Exclude campaigns that don't have details in Drupal API or "Access
+    // denied" due to campaign no longer published
+    if ($result[1] == 201 && is_object($result[0])) {
+      return unseralize($result[0]);
+    }
+    elseif ($result[1] != 201) {
+      throw new Exception('Call to ' . $mbDigestAPIUrl . ' returned ' . $result[1] . ' response.');
+    }
+  }
+
+  /**
+   * campaignSet: POST campaign markup to mb-digest-api for caching.
+   *
+   * @param object $campaign
+   *   A complete campaign object to be cached.
+   * @param string $markup
+   *   HTML markup of the campaign used to generate email message content.
+   */
+  protected function campaignSet($campaign) {
+
+    $post = [
+      'nid' => $$campaign->nid,
+      'language' => $$campaign->language,
+      'object' => seralize($campaign)
+    ];
+
+    $mbDigestAPIUrl = $this->curlUrl . '/api/v1/campaign';
+    $result = $this->mbToolboxcURL->curlPOST($mbDigestAPIUrl, $post);
+
+    if ($result[1] == 200) {
+      // $this->statHat->ezCount('', 1);
+    }
+    else {
+      throw new Exception('- ERROR, MBC_DigestEmail_MandrillMessenger->cacheCampaignMarku(): Failed to POST to ' . $mbDigestAPIUrl . ' Returned POST results: ' . print_r($result, TRUE));
+    }
+  }

--- a/src/MBC_DigestEmail_Campaign.php
+++ b/src/MBC_DigestEmail_Campaign.php
@@ -303,5 +303,27 @@ class MBC_DigestEmail_Campaign {
    */
   private function setCampaignCache($campaignObject) {
 
+    $mbDigestAPIConfig = $this->mbConfig->getProperty('mb_digest_api_config');
+    $curlUrl = $mbDigestAPIConfig['host'];
+    $port = isset($mbDigestAPIConfig['port']) ? $mbDigestAPIConfig['port'] : NULL;
+    if ($port != 0 && is_numeric($port)) {
+      $curlUrl .= ':' . (int) $port;
+    }
+
+    $post = [
+      'nid' => $campaignObject->nid,
+      'language' => $campaignObject->language,
+      'object' => seralize($campaignObject)
+    ];
+
+    $mbDigestAPIUrl = $curlUrl . '/api/v1/campaign';
+    $result = $this->mbToolboxcURL->curlPOST($mbDigestAPIUrl, $post);
+
+    if ($result[1] == 200) {
+      // $this->statHat->ezCount('', 1);
+    }
+    else {
+      throw new Exception('- ERROR, MBC_DigestEmail_Campaign->setCampaignCache(): Failed to POST to ' . $mbDigestAPIUrl . ' Returned POST results: ' . print_r($result, TRUE));
+    }
   }
 }

--- a/src/MBC_DigestEmail_Consumer.php
+++ b/src/MBC_DigestEmail_Consumer.php
@@ -58,6 +58,12 @@ class MBC_DigestEmail_Consumer extends MB_Toolbox_BaseConsumer {
   private $mbcDEMessenger;
 
   /**
+   * A collection of methods to interact with the mb-digest-api.
+   * @var object $mbcDigestEmailAPI
+   */
+  private $mbcDigestEmailAPI;
+
+  /**
    * __construct(): When a new Consumer class is created at the time of starting the mbc-digest-script
    * this method will ensure key variables are constructed.
    */
@@ -76,6 +82,7 @@ class MBC_DigestEmail_Consumer extends MB_Toolbox_BaseConsumer {
 
     $this->mbConfig = MB_Configuration::getInstance();
     $this->mbcDEMessenger = $this->mbConfig->getProperty('mbcDEMessenger');
+    $this->mbcDigestEmailAPI = $this->mbConfig->getProperty('mbcDigestEmailAPI');
   }
 
   /**
@@ -206,12 +213,13 @@ private function waitingUserMessages() {
           $mbcDECampaign = new MBC_DigestEmail_Campaign($campaign['nid']);
         }
         catch (Exception $e) {
-          // @todo: Log/report missing campaign value.
           echo '- MBC_DigestEmail_Consumer->setter(): Error creating MBC_DigestEmail_Campaign object: ' . $e->getMessage(), PHP_EOL;
           $mbcDECampaign = [
             'nid' => $campaign['nid'],
             'creationError' => $e->getMessage(),
           ];
+          // Cache campaign errors for report generation
+          $this->mbcDigestEmailAPI->campaignSet($mbcDECampaign);
         }
         // Add campaign object to concerned properties and related objects.
         $this->campaigns[$campaign['nid']] = $mbcDECampaign;

--- a/src/MBC_DigestEmail_Consumer.php
+++ b/src/MBC_DigestEmail_Consumer.php
@@ -58,13 +58,6 @@ class MBC_DigestEmail_Consumer extends MB_Toolbox_BaseConsumer {
   private $mbcDEMessenger;
 
   /**
-   * Collect errors reported when generating campaign object. The contents of this property will be
-   * used to generate a report of campaigns missing content.
-   * @var array $campaignErrors
-   */
-  private $campaignErrors;
-
-  /**
    * __construct(): When a new Consumer class is created at the time of starting the mbc-digest-script
    * this method will ensure key variables are constructed.
    */
@@ -145,11 +138,6 @@ class MBC_DigestEmail_Consumer extends MB_Toolbox_BaseConsumer {
       // @todo: Support different services based on interface base class
       $status = $this->mbcDEMessenger->sendDigestBatch();
 
-      // @todo: Log digest message activity, include errors encountered generating campaign
-      // objects: $this->campaignErrors
-      //
-      // $this->logStatus();
-
       echo '- unset $this->users: ' . count($this->users), PHP_EOL . PHP_EOL;
       unset($this->users);
     }
@@ -228,16 +216,13 @@ private function waitingUserMessages() {
         // Add campaign object to concerned properties and related objects.
         $this->campaigns[$campaign['nid']] = $mbcDECampaign;
 
-        if (isset($mbcDECampaign->campaignErrors) && count($mbcDECampaign->campaignErrors) > 0) {
-          $this->campaignErrors[$campaign['nid']] = $mbcDECampaign->campaignErrors;
-        }
       }
       else {
         echo '- Campaign ($this->campaigns[]) record nid: ' . $campaign['nid'] . ' already exists.', PHP_EOL;
         $mbcDECampaign = $this->campaigns[$campaign['nid']];
       }
 
-      // Exclude campaings that are not functional Campaign objects.
+      // Exclude campaigns that are not functional Campaign objects (error was returned).
       if (is_object($mbcDECampaign)) {
         $this->mbcDEMessenger->addCampaign($mbcDECampaign);
         $this->mbcDEUser->addCampaign($campaign['nid'], $campaign['signup']);
@@ -321,5 +306,4 @@ private function waitingUserMessages() {
     // Cleanup for processing of next user digest settings
     unset($this->mbcDEUser);
   }
-
 }

--- a/src/MBC_DigestEmail_MandrillMessenger.php
+++ b/src/MBC_DigestEmail_MandrillMessenger.php
@@ -142,23 +142,30 @@ class MBC_DigestEmail_MandrillMessenger extends MBC_DigestEmail_BaseMessenger {
     // Check for existing markup
     if (!(isset($this->campaigns[$campaign->drupal_nid]->markup))) {
 
-      $campaignMarkup = $this->campaignTempate;
-
-      $campaignMarkup = str_replace('*|CAMPAIGN_IMAGE_URL|*', $campaign->image_campaign_cover, $campaignMarkup);
-      $campaignMarkup = str_replace('*|CAMPAIGN_TITLE|*', $campaign->title, $campaignMarkup);
-      $campaignMarkup = str_replace('*|CAMPAIGN_LINK|*', $campaign->url, $campaignMarkup);
-      $campaignMarkup = str_replace('*|CALL_TO_ACTION|*', $campaign->call_to_action, $campaignMarkup);
-
-      if (isset($campaign->latest_news)) {
-        $campaignMarkup = str_replace('*|TIP_TITLE|*',  'News from the team: ', $campaignMarkup);
-        $campaignMarkup = str_replace('*|DURING_TIP|*',  $campaign->latest_news, $campaignMarkup);
+      if ($markup = $this->campaignCacheMarkupLookup($campaign->drupal_nid)) {
+        $this->campaigns[$campaign->drupal_nid]->markup = markup;
       }
       else {
-        $campaignMarkup = str_replace('*|TIP_TITLE|*',  $campaign->during_tip_header, $campaignMarkup);
-        $campaignMarkup = str_replace('*|DURING_TIP|*',  $campaign->during_tip_copy, $campaignMarkup);
-      }
 
-      $this->campaigns[$campaign->drupal_nid]->markup = $campaignMarkup;
+        $campaignMarkup = $this->campaignTempate;
+
+        $campaignMarkup = str_replace('*|CAMPAIGN_IMAGE_URL|*', $campaign->image_campaign_cover, $campaignMarkup);
+        $campaignMarkup = str_replace('*|CAMPAIGN_TITLE|*', $campaign->title, $campaignMarkup);
+        $campaignMarkup = str_replace('*|CAMPAIGN_LINK|*', $campaign->url, $campaignMarkup);
+        $campaignMarkup = str_replace('*|CALL_TO_ACTION|*', $campaign->call_to_action, $campaignMarkup);
+
+        if (isset($campaign->latest_news)) {
+          $campaignMarkup = str_replace('*|TIP_TITLE|*',  'News from the team: ', $campaignMarkup);
+          $campaignMarkup = str_replace('*|DURING_TIP|*',  $campaign->latest_news, $campaignMarkup);
+        }
+        else {
+          $campaignMarkup = str_replace('*|TIP_TITLE|*',  $campaign->during_tip_header, $campaignMarkup);
+          $campaignMarkup = str_replace('*|DURING_TIP|*',  $campaign->during_tip_copy, $campaignMarkup);
+        }
+
+        $this->campaigns[$campaign->drupal_nid]->markup = $campaignMarkup;
+        $this->cacheCampaignMarkup($campaign->drupal_nid, $campaignMarkup);
+      }
     }
   }
 
@@ -493,5 +500,18 @@ class MBC_DigestEmail_MandrillMessenger extends MBC_DigestEmail_BaseMessenger {
     }
     echo 'mandrillResults: ' . print_r($stats, TRUE), PHP_EOL . PHP_EOL;
     unset($this->users);
+  }
+
+  /**
+   * cacheCampaignMarkup: Send campaign markup to mb-digest-api for caching.
+   *
+   * @param integer $nid
+   *   The Drupal defined Node ID (nid) of the campaign object in the
+   *   Drupal application.
+   * @param string $markup
+   *   HTML markup of the campaign used to generate email message content.
+   */
+  protected function cacheCampaignMarkup($nid, $markup) {
+
   }
 }

--- a/src/MBC_DigestEmail_MandrillMessenger.php
+++ b/src/MBC_DigestEmail_MandrillMessenger.php
@@ -144,11 +144,12 @@ class MBC_DigestEmail_MandrillMessenger extends MBC_DigestEmail_BaseMessenger {
    */
   private function generateCampaignMarkup($campaign) {
 
-    // Check for existing markup
+    // Check for existing markup in existing campaign objects in class
     if (!(isset($this->campaigns[$campaign->drupal_nid]->markup))) {
 
-      if ($markup = parent::cacheCampaignLookup($campaign)) {
-        $this->campaigns[$campaign->drupal_nid]->markup = $markup;
+      // Lookup the cached campaign object in mb-digest-api
+      if ($cachedCampaign = $this->mbcDigestEmailAPI->campaignGet($campaign)) {
+        $this->campaigns[$campaign->drupal_nid]->markup = $cachedCampaign->markup;
       }
       else {
 
@@ -170,8 +171,9 @@ class MBC_DigestEmail_MandrillMessenger extends MBC_DigestEmail_BaseMessenger {
 
         $this->campaigns[$campaign->drupal_nid]->markup = $campaignMarkup;
 
-        // Add markup property to cached campaign
-        $this->mbcDigestEmailAPI->campaignSet($campaign);
+        // Add campaign object that includes the markup property to cached
+        // campaign entry in mb-digest-api
+        $this->mbcDigestEmailAPI->campaignSet($this->campaigns[$campaign->drupal_nid]);
       }
     }
   }

--- a/src/MBC_DigestEmail_MandrillMessenger.php
+++ b/src/MBC_DigestEmail_MandrillMessenger.php
@@ -164,7 +164,7 @@ class MBC_DigestEmail_MandrillMessenger extends MBC_DigestEmail_BaseMessenger {
         }
 
         $this->campaigns[$campaign->drupal_nid]->markup = $campaignMarkup;
-        $this->cacheCampaignMarkup($campaign->drupal_nid, $campaignMarkup);
+        $this->cacheCampaignMarkup($campaign->drupal_nid, $campaign->language, $campaignMarkup);
       }
     }
   }
@@ -503,7 +503,7 @@ class MBC_DigestEmail_MandrillMessenger extends MBC_DigestEmail_BaseMessenger {
   }
 
   /**
-   * cacheCampaignMarkup: Send campaign markup to mb-digest-api for caching.
+   * cacheCampaignMarkup: POST campaign markup to mb-digest-api for caching.
    *
    * @param integer $nid
    *   The Drupal defined Node ID (nid) of the campaign object in the
@@ -511,7 +511,29 @@ class MBC_DigestEmail_MandrillMessenger extends MBC_DigestEmail_BaseMessenger {
    * @param string $markup
    *   HTML markup of the campaign used to generate email message content.
    */
-  protected function cacheCampaignMarkup($nid, $markup) {
+  protected function cacheCampaignMarkup($nid, $language, $markup) {
 
+    $mbDigestAPIConfig = $this->mbConfig->getProperty('mb_digest_api_config');
+    $curlUrl = $mbDigestAPIConfig['host'];
+    $port = isset($mbDigestAPIConfig['port']) ? $mbDigestAPIConfig['port'] : NULL;
+    if ($port != 0 && is_numeric($port)) {
+      $curlUrl .= ':' . (int) $port;
+    }
+
+    $post = [
+      'nid' => $nid,
+      'language' => $language,
+      'markup' => $markup
+    ];
+
+    $mbDigestAPIUrl = $curlUrl . '/api/v1/campaign';
+    $result = $this->mbToolboxcURL->curlPOST($mbDigestAPIUrl, $post);
+
+    if ($result[1] == 200) {
+      // $this->statHat->ezCount('', 1);
+    }
+    else {
+      throw new Exception('- ERROR, MBC_DigestEmail_MandrillMessenger->cacheCampaignMarku(): Failed to POST to ' . $mbDigestAPIUrl . ' Returned POST results: ' . print_r($result, TRUE));
+    }
   }
 }


### PR DESCRIPTION
Fixes #70 

Functionality related to concurrency for campaigns within the Digest system. This PR adds:
- Use of `mb-digest-api` cached campaign entries (add / update).
- Use of `mb-digest-api` to cache campaign markup and assign to cached campaign object data.

In both cases the goal is to cache campaign data in a processed format to allow several consumers to run in parallel and not request and process the same campaign entries.
