### PR TITLE
Fixes fatal error: class DoSomething\MBC_DigestEmail\Exception not found.

### DIFF
--- a/src/MBC_DigestEmail_BaseMessenger.php
+++ b/src/MBC_DigestEmail_BaseMessenger.php
@@ -5,6 +5,7 @@
  */
 
 namespace DoSomething\MBC_DigestEmail;
+use \Exception;
 
 
 /**

--- a/src/MBC_DigestEmail_MandrillMessenger.php
+++ b/src/MBC_DigestEmail_MandrillMessenger.php
@@ -9,6 +9,7 @@ namespace DoSomething\MBC_DigestEmail;
 use DoSomething\MB_Toolbox\MB_Configuration;
 use DoSomething\StatHat\Client as StatHat;
 use DoSomething\MB_Toolbox\MB_Toolbox;
+use \Exception;
 
 /**
  * MBC_DigestEmail_MandrillMessenger class - 


### PR DESCRIPTION
See http://php.net/manual/en/language.namespaces.fallback.php, Accessing global classes inside a namespace.
