### PR TITLE
Issue65 5 weeks

### DIFF
--- a/src/MBC_DigestEmail_User.php
+++ b/src/MBC_DigestEmail_User.php
@@ -234,7 +234,7 @@ class MBC_DigestEmail_User
   }
 
   /**
-   * Filter campaigns to meet requirments to be included in digest messages.
+   * Filter campaigns to meet requirements for including a campaign in user digest message.
    *
    * @param array $userCampaigns
    *   A list of user campaigns to apply filters to.
@@ -248,17 +248,22 @@ class MBC_DigestEmail_User
     $filteredUserCampaigns = [];
     foreach ($userCampaigns as $userCampaignNID => $userCampaign) {
 
-      // @todo: Prevent users seeing a campaign in their digest more than five times. Exclude campaigns
-      // that the user has signed up for over five weeks in the past.
-
-      // Include active campaigns
-      if (isset($campaigns[$userCampaignNID]->status) && $campaigns[$userCampaignNID]->status == 'active') {
-        $filteredUserCampaigns[$userCampaignNID] = $userCampaign;
+      // Prevent users seeing a campaign in their digest more than five times. Exclude campaigns
+      // that the user has signed up for over five weeks in the past based on the digest message
+      // being sent weekly.
+      if ($userCampaign < strtotime("-5 week")) {
+        continue;
       }
-    }
-    $userCampaigns = $filteredUserCampaigns;
 
-    return $userCampaigns;
+      // Exclude inactive campaigns
+      if (empty($campaigns[$userCampaignNID]->status) || $campaigns[$userCampaignNID]->status != 'active') {
+        continue;
+      }
+
+      $filteredUserCampaigns[$userCampaignNID] = $userCampaign;
+    }
+
+    return $filteredUserCampaigns;
   }
 
   /**


### PR DESCRIPTION
Fixes #65 

- Creation of `sendBatch()` to move logic that determines if a batch of digest messages should be sent into it's own method. The logic was getting to complicated to be a single line of nested ANDs and ORs.
- Moved `$this->users[] = $this->mbcDEUser;` to `process()` out of `setter()` as values in `$this->users` could be invalid based on the results of processing user campaigns.
- Aff 5 week filter to user campaigns: `$userCampaign < strtotime("-5 week")`.
 