### PR TITLE
Fails `@mobile.import` addresses

### DIFF
--- a/src/MBC_DigestEmail_Consumer.php
+++ b/src/MBC_DigestEmail_Consumer.php
@@ -267,6 +267,11 @@ private function waitingUserMessages() {
       return FALSE;
     }
 
+    if (preg_match('/@mobile\.import$/', $this->message['email'])) {
+      echo '- canProcess(), Mobile placeholder address: ' . $this->message['email'], PHP_EOL;
+      return false;
+    }
+
     // Must have drupal_uid (for unsubscribe link)
     if (!isset($this->message['drupal_uid'])) {
       echo 'MBC_DigestEmail_Consumer->canProcess(): Message missing uid (Drupal node ID).', PHP_EOL;


### PR DESCRIPTION
Adds a check in `canProcess()` to fail email addresses that end in `@mobile.import`.

Exact copy of DoSomething/mbc-transactional-email#40.
Fixes #84.
